### PR TITLE
fix: 141 Linked List Cycle.js

### DIFF
--- a/141 Linked List Cycle.js
+++ b/141 Linked List Cycle.js
@@ -62,7 +62,7 @@ var hasCycle = function(head) {
     node2 = node2.next;
     
     while(node1 !== null && node2 !== null) {
-        if (node1.val === node2.val) {
+        if (node1 === node2) {
             return true;
         }
 


### PR DESCRIPTION
when case is 
```
[1,1,1,1], pos=-1
```
it not work